### PR TITLE
Include TestBash Manchester

### DIFF
--- a/data/groups.json
+++ b/data/groups.json
@@ -10,6 +10,17 @@
      "advertised": "Twitter, Eventbrite"
  },
 	{
+	"name": "TestBash Manchester",
+	"description": "A single track conference all about software testing",
+	"organiser": "Richard Bradshaw",
+	"email": "RichardBradshaw@gmail.com",
+	"where": "The Lowry",
+	"when": "October 21st 2016",
+	"twitter": "@ministryoftest",
+	"website": "http://www.ministryoftesting.com/training-events/testbash-manchester/",
+	"advertised": "Website, Twitter, etc"
+},
+	{
 	"name": "AWS User Group North",
 	"description": "Amazon Web Services User Group for Manchester & the north west",
 	"organiser": "Alex McConnell",


### PR DESCRIPTION
TestBash Manchester is a 1 day single track conference building on the success of TestBash Brighton.

Thanks,

Duncs
