### PR TITLE
Correct twitter account for LambdaLounge

### DIFF
--- a/data/groups.json
+++ b/data/groups.json
@@ -264,7 +264,7 @@
 	"email": "rick.moynihan@gmail.com",
 	"where": "MadLab",
 	"when": "3rd Monday",
-	"twitter": "#lambdalounge",
+	"twitter": "@lambdamcr",
 	"website": "http://www.lambdalounge.org.uk/",
 	"advertised": "Google group// MadLab website// Twitter "
 }, {


### PR DESCRIPTION
Hi @rubygem! This corrects the twitter for LambdaLounge which was a) wrong, b) in the wrong format ;-)